### PR TITLE
fix dependency broken

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,4 +32,4 @@ flower==1.2.0
 django-celery-beat==2.3.0
 pytest-xdist[psutil]==2.5.0
 django-extensions==3.2.0
-PyYAML==6.0
+PyYAML==6.0.1


### PR DESCRIPTION
**Solution to Fix with pyYaml dependency**

> The version in the requirements.txt file is changed to version 6.0.1 for compatibility with Cython 3.0.